### PR TITLE
Fixes bug with undefined loci

### DIFF
--- a/parse_blast_report.pl
+++ b/parse_blast_report.pl
@@ -204,7 +204,7 @@ foreach my $locus (keys %map_loci) {
 	next unless $loci{$locus};
 	print OUT $locus, ',';
 	foreach my $lg (keys %map) {
-		if ($map{$lg}{$locus}) {
+		if (defined $map{$lg}{$locus}) {
 			print OUT join(',', $lg, $map_mod{$lg}{$locus}, $map{$lg}{$locus}), ',';
 			last;
 		}


### PR DESCRIPTION
Fixes bug caused when a locus is at position '0' on the linkage map is interpreted as missing. Adding an explicit 'defined' fixes this.
