### PR TITLE
fixes bug with blocks starting at map position zero

### DIFF
--- a/id_syntenic_blocks.pl
+++ b/id_syntenic_blocks.pl
@@ -185,7 +185,7 @@ foreach my $lg (keys %blocks) {
 		push @comp_block_size, $comp_size;
 		my $map_lg;
 		foreach my $group (keys %lgs) {
-			if ($lgs{$group}{$block->[0]}) {
+			if (defined $lgs{$group}{$block->[0]}) {
 				$map_lg = $group;
 				$map_lg =~ s/LG//;
 				last;


### PR DESCRIPTION
Fixes a bug where the map chromosome fails to print when the syntenic block starts at map position zero.
